### PR TITLE
byoc-stream: add comments for custom TLS certificate configuration in Caddyfile

### DIFF
--- a/byoc-stream/docker-compose.yml
+++ b/byoc-stream/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     volumes:
       - ./webserver/Caddyfile:/etc/caddy/Caddyfile
       - ./webapp/dist:/var/www/html/app
+      # Uncomment to use custom certificates
+      # - ./certs:/certs 
     environment:
       - HOST=${HOST}
       - HTTPS_PORT=${HTTPS_PORT}

--- a/byoc-stream/webserver/Caddyfile
+++ b/byoc-stream/webserver/Caddyfile
@@ -9,6 +9,9 @@ https://{$HOST}:{$HTTPS_PORT} {
 	}
 
 	tls {$HTTPS_EMAIL}
+	# Uncomment to use custom certificates
+	# mount volume to /certs folder in docker-compose.yml
+	# tls /certs/fullchain.pem /certs/privkey.pem
 
 	handle_path /ai-runner/* {
 		header {


### PR DESCRIPTION
Just adds a comment to the Caddyfile as a reminder when deploying as a server using custom certificates